### PR TITLE
camel case mobilesrc breaks ff

### DIFF
--- a/videoplayer/static/videoplayer/videoplayer.js
+++ b/videoplayer/static/videoplayer/videoplayer.js
@@ -214,7 +214,7 @@ export class VideoPlayer {
       const desktopSrc = source.dataset.src
       let mobileSrc = ''
       if (getWindowWidth() <= this.options.phoneMax) {
-        mobileSrc = source.dataset.mobileSrc
+        mobileSrc = source.dataset.mobilesrc
       }
       if (mobileSrc) {
         source.setAttribute('src', mobileSrc)
@@ -891,7 +891,7 @@ export class VideoPlayer {
       forEach(data.sources, sourceDict => {
         const newSource = document.createElement('source')
         newSource.dataset.src = sourceDict.source
-        newSource.dataset.mobileSrc = sourceDict.mobileSource
+        newSource.dataset.mobilesrc = sourceDict.mobileSource
         newSource.setAttribute('type', sourceDict.type)
         this.video.appendChild(newSource)
       })

--- a/videoplayer/templates/videoplayer/videoplayer.html
+++ b/videoplayer/templates/videoplayer/videoplayer.html
@@ -26,7 +26,7 @@
            {% if playsinline %} playsinline {% endif %}>
       {% for desktop, mobile, type in sources %}
         <source data-src='{{ desktop }}'
-                {% if mobile %} data-mobileSrc='{{ mobile }}' {% endif %}
+                {% if mobile %} data-mobilesrc='{{ mobile }}' {% endif %}
                 type='{{ type }}'>
       {% endfor %}
     </video>


### PR DESCRIPTION
Noticed that firefox does not like the camel case on data attributes.